### PR TITLE
Build fails with scons > 4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyChromecast>=2.3.0
 netifaces>=0.10.5
 python-daemon>=2.2.0
-scons>=3.0.1
+scons>=3.0.1,<4.2


### PR DESCRIPTION
If I set `scons>=3.0.1,<4.2` in `requirements.txt`, build succeeds.
I've found plutinosoft/Platinum#18 while searching for a solution. I guess it has something to do with it.
Just in case, a temp fix PR will follow shortly.

Relevant build log (on a Docker build):
```
Step 8/10 : RUN   git submodule update --init --recursive --depth 1
 ---> Running in 750500d32033
Submodule path 'thirdparty/platinum': checked out 'b7001eff8d87e95e5932a99214d6bdb70df30c7d'
Submodule 'ThirdParty/Neptune' (https://github.com/plutinosoft/Neptune.git) registered for path 'thirdparty/platinum/ThirdParty/Neptune'
Cloning into '/usr/src/app/thirdparty/platinum/ThirdParty/Neptune'...
From https://github.com/plutinosoft/Neptune
 * branch            9481baf101edc398678d13e7981ae566514682da -> FETCH_HEAD
Submodule path 'thirdparty/platinum/ThirdParty/Neptune': checked out '9481baf101edc398678d13e7981ae566514682da'
Removing intermediate container 750500d32033
 ---> 88d8c6650939
Step 9/10 : RUN scons --version
 ---> Running in 664a3b39e67e
SCons by Steven Knight et al.:
	SCons: v4.3.0.559790274f66fa55251f5754de34820a29c7327a, Tue, 16 Nov 2021 19:09:21 +0000, by bdeegan on octodog
	SCons path: ['/usr/local/lib/python3.10/site-packages/SCons']
Copyright (c) 2001 - 2021 The SCons Foundation
Removing intermediate container 664a3b39e67e
 ---> 8ccee6ba0661
Step 10/10 : RUN make --makefile=Makefile.mediarenderer
 ---> Running in 529b8910b454
scons -C thirdparty/platinum -c
scons: Entering directory `/usr/src/app/thirdparty/platinum'
scons: Reading SConscript files ...
********** Configuring Build Target = x86_64-unknown-linux / Debug ********
AttributeError: 'SConsEnvironment' object has no attribute 'has_key':
  File "/usr/src/app/thirdparty/platinum/SConstruct", line 1:
    SConscript('Build/Boot.scons')
  File "/usr/local/lib/python3.10/site-packages/SCons/Script/SConscript.py", line 660:
    return method(*args, **kw)
  File "/usr/local/lib/python3.10/site-packages/SCons/Script/SConscript.py", line 597:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/usr/local/lib/python3.10/site-packages/SCons/Script/SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/usr/src/app/thirdparty/platinum/Build/Boot.scons", line 106:
    SConscript('Build.scons', variant_dir='Targets/'+env['target']+'/'+build_config, exports='env', duplicate=0)
  File "/usr/local/lib/python3.10/site-packages/SCons/Script/SConscript.py", line 660:
    return method(*args, **kw)
  File "/usr/local/lib/python3.10/site-packages/SCons/Script/SConscript.py", line 597:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/usr/local/lib/python3.10/site-packages/SCons/Script/SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/usr/src/app/thirdparty/platinum/Build/Build.scons", line 236:
    if not env.has_key('NPT_CONFIG_NO_ZIP'):
make: *** [Makefile.mediarenderer:5: all] Error 2
Removing intermediate container 529b8910b454
The command '/bin/sh -c make --makefile=Makefile.mediarenderer' returned a non-zero code: 2
```